### PR TITLE
Make some finetuning parameters available to pass from command line

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -3,3 +3,21 @@ sizes   = 16 32 64 128 256
 strides = 8 16 32 64 128
 ratios  = 0.5 1 2 3
 scales  = 1 1.2 1.6
+
+[random_transform_parameters]
+min_rotation = -0.1
+max_rotation = 0.1
+min_translation = -0.1 -0.1
+max_translation = 0.1 0.1
+min_shear = -0.1
+max_shear = 0.1
+min_scaling = 0.9 0.9
+max_scaling = 1.1 1.1
+flip_x_chance = 0.5
+flip_y_chance = 0.1
+
+[visual_effect_parameters]
+contrast_range = 0.9 1.1
+brightness_range = -.1 .1
+hue_range = -0.05 0.05
+saturation_range = 0.95 1.05

--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -45,3 +45,29 @@ def parse_anchor_parameters(config):
     strides = list(map(int, config['anchor_parameters']['strides'].split(' ')))
 
     return AnchorParameters(sizes, strides, ratios, scales)
+
+
+def parse_random_transform_parameters(config):
+    kwargs = dict()
+    kwargs['min_rotation'] = float(config['random_transform_parameters']['min_rotation'])
+    kwargs['max_rotation'] = float(config['random_transform_parameters']['max_rotation'])
+    kwargs['min_translation'] = tuple(map(float, config['random_transform_parameters']['min_translation'].split()))
+    kwargs['max_translation'] = tuple(map(float, config['random_transform_parameters']['max_translation'].split()))
+    kwargs['min_shear'] = float(config['random_transform_parameters']['min_shear'])
+    kwargs['max_shear'] = float(config['random_transform_parameters']['max_shear'])
+    kwargs['min_scaling'] = tuple(map(float, config['random_transform_parameters']['min_scaling'].split()))
+    kwargs['max_scaling'] = tuple(map(float, config['random_transform_parameters']['max_scaling'].split()))
+    kwargs['flip_x_chance'] = float(config['random_transform_parameters']['flip_x_chance'])
+    kwargs['flip_y_chance'] = float(config['random_transform_parameters']['flip_y_chance'])
+
+    return kwargs
+
+
+def parse_visual_effect_parameters(config):
+    kwargs = dict()
+    kwargs['contrast_range'] = tuple(map(float, config['visual_effect_parameters']['contrast_range'].split()))
+    kwargs['brightness_range'] = tuple(map(float, config['visual_effect_parameters']['brightness_range'].split()))
+    kwargs['hue_range'] = tuple(map(float, config['visual_effect_parameters']['hue_range'].split()))
+    kwargs['saturation_range'] = tuple(map(float, config['visual_effect_parameters']['saturation_range'].split()))
+
+    return kwargs


### PR DESCRIPTION
Make some model's parameters to be configurable from the command line in order to finetune training process. Parameters added:

- clipnorm for optimizer
- alpha parameter of the focal loss
- gamma parameter of the focal loss
- loss weights of regression and classification subnetworks
- update frequency for Tensorboard logs

Parameters of random_transform_generator and visual_effects_generator are made configurable through config.ini along with anchors.

The random-transform parameter was replaced with no-random-transform, as we use random-transform by default. 
